### PR TITLE
Add /ask-kent skill router

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Or install one:
 
 ```sh
 npx skills add kentcdodds/kcd-skills --skill ask-kent
-npx skills add kentcdodds/kcd-skills --skill orchistrate
+npx skills add kentcdodds/kcd-skills --skill orchestrate
 npx skills add kentcdodds/kcd-skills --skill visual-recap
 npx skills add kentcdodds/kcd-skills --skill ship-pr
 ```
@@ -33,8 +33,8 @@ Add `--global` to make the skills available across projects.
 
 - `ask-kent` is the router: describe the situation, get the next `/skill` to
   type. It recommends and stops.
-- `orchistrate` coordinates sub-agents for large tasks (plan, delegate, review,
-  integrate). Not Cursor's `/orchestrate` plugin.
+- `orchestrate` coordinates sub-agents for large tasks (plan, delegate, review,
+  integrate). Not Cursor's cloud-agent `/orchestrate` plugin.
 - `visual-recap` creates and maintains a visual system recap in a pull request.
 - `ship-pr` iterates on CI and review feedback until a pull request is ready.
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ modify the skills for your own workflows.
 
 ## Install
 
-Install both skills:
+Install every skill:
 
 ```sh
 npx skills add kentcdodds/kcd-skills
@@ -21,6 +21,8 @@ npx skills add kentcdodds/kcd-skills
 Or install one:
 
 ```sh
+npx skills add kentcdodds/kcd-skills --skill ask-kent
+npx skills add kentcdodds/kcd-skills --skill orchistrate
 npx skills add kentcdodds/kcd-skills --skill visual-recap
 npx skills add kentcdodds/kcd-skills --skill ship-pr
 ```
@@ -29,6 +31,10 @@ Add `--global` to make the skills available across projects.
 
 ## Skills
 
+- `ask-kent` is the router: describe the situation, get the next `/skill` to
+  type. It recommends and stops.
+- `orchistrate` coordinates sub-agents for large tasks (plan, delegate, review,
+  integrate). Not Cursor's `/orchestrate` plugin.
 - `visual-recap` creates and maintains a visual system recap in a pull request.
 - `ship-pr` iterates on CI and review feedback until a pull request is ready.
 

--- a/skills/ask-kent/SKILL.md
+++ b/skills/ask-kent/SKILL.md
@@ -134,4 +134,4 @@ the slash command anyway.
 - Close skills get one concrete test for why the other is wrong.
 - Any load-bearing claim about another skill shows up as a read of that
   `SKILL.md`.
-- You recognise your situation, not the nearest generic scenario.
+- You recognize your situation, not the nearest generic scenario.

--- a/skills/ask-kent/SKILL.md
+++ b/skills/ask-kent/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: ask-kent
+description: >
+  Ask which kcd-skills flow fits your situation. A router over the skills in
+  this repo. Use when you don't know which Kent skill to run, or which order.
+disable-model-invocation: true
+---
+
+# Ask Kent
+
+You don't remember every skill, so ask.
+
+A **flow** is a path through the skills. Most work travels one **main flow**.
+Everything else is a close call or a skip.
+
+## How to answer
+
+1. Place the situation on the main flow at a step.
+2. Name the next `/skill` to type, and why the near-miss is wrong.
+3. Say where a human decision sits (architecture, recap classification, merge).
+4. **Stop.** Do not start the work. Do not invoke the skill you named.
+5. If a claim about another skill matters, read that `SKILL.md` first. This map
+   is a secondary source. The skill file wins.
+
+This is a **hand-written map of this repo**. Do not scan `skills/`, do not route
+over repo-local skills (Kody's `conduct`, `remix`, …), and do not route over
+another author's skills. Cursor's `/orchestrate` plugin is a different skill
+from `/orchistrate` here.
+
+If they already know the skill, tell them to invoke it. `/ask-kent` has nothing
+useful to add.
+
+## The main flow: idea → ship
+
+The route most work travels.
+
+```mermaid
+flowchart TD
+	sit[Situation] --> big{Large or parallel?}
+	big -->|yes| orch["/orchistrate"]
+	big -->|no| plan{Non-trivial system change?}
+	orch --> plan
+	plan -->|yes| vplan["/visual-recap plan"]
+	plan -->|no| build[Build]
+	vplan --> build
+	build --> recap{PR + worth a system map?}
+	recap -->|yes| vrecap["/visual-recap recap"]
+	recap -->|no| ship["/ship-pr"]
+	vrecap --> ship
+```
+
+1. **Branch: is this large, multi-stream, or too much for one agent?**
+   - **Yes** → **`/orchistrate`**. Two modes: **be** the orchestrator (plan,
+     delegate, review, integrate), or **spawn** one if you are a cheap/fast
+     model. Frontier model orchestrates; cheap/fast models implement. You do the
+     QA — never declare done from sub-agent reports.
+   - **No** → stay in this session and build it. Fan-out that does not pay is
+     orchestration theater.
+
+2. **Branch: is the change non-trivial?** System primitives, architecture,
+   contracts, review-critical behavior.
+   - **Yes** → **`/visual-recap` in plan mode** before you implement. Classify
+     against `docs/contributing/architecture/primitives.yaml` in the _working_
+     repo. Lowest-risk outcome: the plan requires **no** primitive change — say
+     so.
+   - **No** → skip. A tiny, obvious diff reviews faster as a plain diff.
+
+3. **Build.** `/orchistrate` delegates this. A small change you just do.
+
+4. **PR exists** → **`/visual-recap` in recap mode**. Reads
+   `git diff <base>...HEAD`, not memory. Replaces a plan-mode block. Re-run
+   after significant new commits.
+
+5. **Babysit until it's landed** → **`/ship-pr`**. Mark ready, wait on CI
+   (composes `loop-on-ci` / `fix-ci`), address valid review feedback, rebase if
+   needed. Merge only if asked or the change is low risk. Always
+   Discord-summarize via `kody:@kentcdodds/discord/send-shipped-pr` — never raw
+   `post-message`, never guess token cost.
+
+Keep plan → recap → ship in the repo that owns the PR. `/orchistrate` is the
+parent session; implementer context is disposable.
+
+## Situation → route
+
+| Your situation                                 | Type this                                     | Not this                                 |
+| ---------------------------------------------- | --------------------------------------------- | ---------------------------------------- |
+| Idea is big, parallel, or multi-stream         | `/orchistrate`                                | Building it all yourself                 |
+| You are a cheap/fast model handed a large task | `/orchistrate` (spawn a smarter orchestrator) | Doing the bulk coding                    |
+| Planning a non-trivial change                  | `/visual-recap` (plan)                        | Recap mode — the work does not exist yet |
+| PR needs a system-level summary                | `/visual-recap` (recap)                       | Plan mode — read the diff                |
+| Tiny, obvious diff                             | skip `visual-recap`                           | A recap nobody will open                 |
+| CI, review, merge, Discord summary             | `/ship-pr`                                    | Re-explaining the babysit loop           |
+| Already know the skill                         | that skill                                    | `/ask-kent`                              |
+| Working repo has no `primitives.yaml`          | say so; don't fake a recap                    | Inventing primitive ids                  |
+| Not Kent / no Kody Discord exports             | fork `ship-pr` or skip Discord                | Pretending the Discord step will work    |
+
+## Close calls
+
+The useful part of this map. One concrete test each.
+
+- **`/orchistrate` vs just build.** Can one agent finish the critical path in
+  this window without file conflicts? If yes, build. Fan out only when
+  independent workstreams clearly beat one implementer.
+- **`/orchistrate` vs Cursor `/orchestrate`.** This repo's skill is
+  **`/orchistrate`** (the extra `r`): sub-agents in one environment, model
+  split, you QA. Cursor's plugin fans work across cloud agents via its own SDK.
+  This map only names `/orchistrate`.
+- **`visual-recap` plan vs recap.** Does the work exist? Plan describes the
+  intended change. Recap describes the diff. Never recap from session memory.
+- **`visual-recap` vs skip.** Would a reviewer benefit from a system map
+  _before_ the diff? If no, skip. Recap is review overhead.
+- **`ship-pr` vs "just merge it".** Need the CI/review loop and the Discord
+  summary? That's `/ship-pr`. Merge is a branch inside it, not a different
+  skill.
+
+## Preconditions
+
+The router names skills; it does not install them.
+`npx skills add kentcdodds/kcd-skills` (or `--skill <name>`). Skills with
+`disable-model-invocation: true` (`ask-kent`, `orchistrate`) still exist — type
+the slash command anyway.
+
+- **`/visual-recap`** needs `docs/contributing/architecture/primitives.yaml` in
+  the working repo, plus `gh` auth to upsert the PR block.
+- **`/ship-pr`** needs `gh` auth and Kent's Kody packages
+  (`kody:@kentcdodds/github`, `kody:@kentcdodds/discord`). The Discord step is
+  Kent-specific.
+- **`/orchistrate`** needs a harness that can spawn sub-agents.
+
+## It's working if
+
+- It ends by naming what to type and **stops**, instead of starting the work.
+- The route says where you review or verify, not just a list of skill names.
+- Close skills get one concrete test for why the other is wrong.
+- Any load-bearing claim about another skill shows up as a read of that
+  `SKILL.md`.
+- You recognise your situation, not the nearest generic scenario.

--- a/skills/ask-kent/SKILL.md
+++ b/skills/ask-kent/SKILL.md
@@ -24,8 +24,8 @@ Everything else is a close call or a skip.
 
 This is a **hand-written map of this repo**. Do not scan `skills/`, do not route
 over repo-local skills (Kody's `conduct`, `remix`, …), and do not route over
-another author's skills. Cursor's `/orchestrate` plugin is a different skill
-from `/orchistrate` here.
+another author's skills. Cursor's cloud-agent `/orchestrate` plugin is a
+different skill from this repo's `/orchestrate`.
 
 If they already know the skill, tell them to invoke it. `/ask-kent` has nothing
 useful to add.
@@ -37,7 +37,7 @@ The route most work travels.
 ```mermaid
 flowchart TD
 	sit[Situation] --> big{Large or parallel?}
-	big -->|yes| orch["/orchistrate"]
+	big -->|yes| orch["/orchestrate"]
 	big -->|no| plan{Non-trivial system change?}
 	orch --> plan
 	plan -->|yes| vplan["/visual-recap plan"]
@@ -50,7 +50,7 @@ flowchart TD
 ```
 
 1. **Branch: is this large, multi-stream, or too much for one agent?**
-   - **Yes** → **`/orchistrate`**. Two modes: **be** the orchestrator (plan,
+   - **Yes** → **`/orchestrate`**. Two modes: **be** the orchestrator (plan,
      delegate, review, integrate), or **spawn** one if you are a cheap/fast
      model. Frontier model orchestrates; cheap/fast models implement. You do the
      QA — never declare done from sub-agent reports.
@@ -65,7 +65,7 @@ flowchart TD
      so.
    - **No** → skip. A tiny, obvious diff reviews faster as a plain diff.
 
-3. **Build.** `/orchistrate` delegates this. A small change you just do.
+3. **Build.** `/orchestrate` delegates this. A small change you just do.
 
 4. **PR exists** → **`/visual-recap` in recap mode**. Reads
    `git diff <base>...HEAD`, not memory. Replaces a plan-mode block. Re-run
@@ -77,15 +77,15 @@ flowchart TD
    Discord-summarize via `kody:@kentcdodds/discord/send-shipped-pr` — never raw
    `post-message`, never guess token cost.
 
-Keep plan → recap → ship in the repo that owns the PR. `/orchistrate` is the
+Keep plan → recap → ship in the repo that owns the PR. `/orchestrate` is the
 parent session; implementer context is disposable.
 
 ## Situation → route
 
 | Your situation                                 | Type this                                     | Not this                                 |
 | ---------------------------------------------- | --------------------------------------------- | ---------------------------------------- |
-| Idea is big, parallel, or multi-stream         | `/orchistrate`                                | Building it all yourself                 |
-| You are a cheap/fast model handed a large task | `/orchistrate` (spawn a smarter orchestrator) | Doing the bulk coding                    |
+| Idea is big, parallel, or multi-stream         | `/orchestrate`                                | Building it all yourself                 |
+| You are a cheap/fast model handed a large task | `/orchestrate` (spawn a smarter orchestrator) | Doing the bulk coding                    |
 | Planning a non-trivial change                  | `/visual-recap` (plan)                        | Recap mode — the work does not exist yet |
 | PR needs a system-level summary                | `/visual-recap` (recap)                       | Plan mode — read the diff                |
 | Tiny, obvious diff                             | skip `visual-recap`                           | A recap nobody will open                 |
@@ -98,13 +98,13 @@ parent session; implementer context is disposable.
 
 The useful part of this map. One concrete test each.
 
-- **`/orchistrate` vs just build.** Can one agent finish the critical path in
+- **`/orchestrate` vs just build.** Can one agent finish the critical path in
   this window without file conflicts? If yes, build. Fan out only when
   independent workstreams clearly beat one implementer.
-- **`/orchistrate` vs Cursor `/orchestrate`.** This repo's skill is
-  **`/orchistrate`** (the extra `r`): sub-agents in one environment, model
-  split, you QA. Cursor's plugin fans work across cloud agents via its own SDK.
-  This map only names `/orchistrate`.
+- **This `/orchestrate` vs Cursor's plugin.** Same slash name, different job.
+  This skill keeps sub-agents in one environment, splits models, and has you QA.
+  Cursor's plugin fans work across cloud agents via its own SDK. This map only
+  names this repo's skill.
 - **`visual-recap` plan vs recap.** Does the work exist? Plan describes the
   intended change. Recap describes the diff. Never recap from session memory.
 - **`visual-recap` vs skip.** Would a reviewer benefit from a system map
@@ -117,7 +117,7 @@ The useful part of this map. One concrete test each.
 
 The router names skills; it does not install them.
 `npx skills add kentcdodds/kcd-skills` (or `--skill <name>`). Skills with
-`disable-model-invocation: true` (`ask-kent`, `orchistrate`) still exist — type
+`disable-model-invocation: true` (`ask-kent`, `orchestrate`) still exist — type
 the slash command anyway.
 
 - **`/visual-recap`** needs `docs/contributing/architecture/primitives.yaml` in
@@ -125,7 +125,7 @@ the slash command anyway.
 - **`/ship-pr`** needs `gh` auth and Kent's Kody packages
   (`kody:@kentcdodds/github`, `kody:@kentcdodds/discord`). The Discord step is
   Kent-specific.
-- **`/orchistrate`** needs a harness that can spawn sub-agents.
+- **`/orchestrate`** needs a harness that can spawn sub-agents.
 
 ## It's working if
 

--- a/skills/orchestrate/SKILL.md
+++ b/skills/orchestrate/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: orchistrate
+name: orchestrate
 description: >
   Orchestrate sub-agents for large tasks: plan, delegate coding to cheap/fast
   models, parallelize the critical path, layer reviews, and close every loop
@@ -8,7 +8,7 @@ description: >
 disable-model-invocation: true
 ---
 
-# Orchistrate
+# Orchestrate
 
 Two modes. Pick one:
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Skill routers like Matt Pocock’s `/ask-matt` are a map of one set of skills: you describe the situation, get the next slash command, and the agent stops. [Adam asked for `/ask-kent`](https://x.com/_overment/status/2092984128417223016) on the back of [Matt’s tweet](https://x.com/mattpocockuk/status/2092939258243772866).

This adds that router for `kcd-skills`.

## What `/ask-kent` does

- Places you on the **idea → ship** flow: `/orchestrate` → `/visual-recap` (plan) → build → `/visual-recap` (recap) → `/ship-pr`
- Names the next `/skill` and **stops** — it does not start the work
- Distinguishes close calls with one concrete test (`orchestrate` vs just build, plan vs recap, recap vs skip, `ship-pr` vs “just merge it”)
- Is a hand-written map of **this repo only** (not Kody-local skills, not Cursor’s cloud-agent `/orchestrate` plugin)
- Treats each `SKILL.md` as the source of truth

`disable-model-invocation: true`, same as `/ask-matt` and `/orchestrate`: type `/ask-kent`.

## Also

- Renamed the `orchistrate` skill to `orchestrate` (folder, frontmatter, heading, and references). The extra `r` was a typo.
- The README now indexes `ask-kent` and `orchestrate` (the latter was missing from the index).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bf40df29-5c6c-492d-a6cf-3920459e9ef0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bf40df29-5c6c-492d-a6cf-3920459e9ef0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the `ask-kent` skill to recommend the appropriate next workflow based on the current task.
  - Added routing guidance for planning, coordination, visual recaps, and pull request workflows.

- **Documentation**
  - Corrected the skill name from `orchistrate` to `orchestrate` throughout installation instructions and descriptions.
  - Clarified that `orchestrate` is distinct from Cursor’s cloud-agent plugin.
  - Documented workflow decision points and prerequisites for selecting skills.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->