### PR TITLE
Tell ship-pr to trigger BugBot via kody:@kentcdodds/bugbot

### DIFF
--- a/skills/ship-pr/SKILL.md
+++ b/skills/ship-pr/SKILL.md
@@ -48,8 +48,10 @@ use raw `post-message` and do **not** compute or guess token cost — the export
 fetches the billed Cursor Cloud Agent usage and formats the cost line.
 
 **agentId (required):**
-- In a Cursor Cloud Agent VM, read it from the metadata socket:
-  curl -fsS --unix-socket "${CURSOR_AGENT_SOCKET:-/run/cursor/api.sock}" http://cursor-agent/v1/meta-data/agent/id
+
+- In a Cursor Cloud Agent VM, read it from the metadata socket: curl -fsS
+  --unix-socket "${CURSOR_AGENT_SOCKET:-/run/cursor/api.sock}"
+  http://cursor-agent/v1/meta-data/agent/id
 - Otherwise pass the `bc-` id from the agent URL you were launched as
   (https://cursor.com/agents/{id}).
 

--- a/skills/ship-pr/SKILL.md
+++ b/skills/ship-pr/SKILL.md
@@ -7,6 +7,17 @@ description: >
 
 # Ship PR
 
+## AI reviewers
+
+Prefer Cursor Bugbot. Never comment `bugbot run` or `cursor review` yourself
+(kody-bot cannot trigger BugBot). Trigger with `kody:@kentcdodds/bugbot` using
+`{ prUrl }` or `{ owner, repo, prNumber }`. Do not pass a GitHub account.
+
+```javascript
+import triggerBugbot from 'kody:@kentcdodds/bugbot'
+await triggerBugbot({ prUrl })
+```
+
 ## Loop
 
 1. Mark ready — `kody:@kentcdodds/github/pr/set-review-status` with


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
kody-bot is not authorized to trigger Cursor BugBot. Agents that comment `bugbot run` (or `cursor review`) as kody-bot get skipped.

This adds a short AI reviewers note to the canonical `ship-pr` skill so agents use `kody:@kentcdodds/bugbot` instead. That package always posts the trigger as kentcdodds. Call it with `{ prUrl }` or `{ owner, repo, prNumber }` — do not pass a GitHub account.

Loop and merge sections are unchanged.

Not merged. No `bugbot run` comment on this PR.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-df526da5-c422-4042-86ab-813ef5e6df53?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-df526da5-c422-4042-86ab-813ef5e6df53&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for using AI-powered code reviewers during the pull request workflow.
  * Clarified recommended review triggers and included a JavaScript usage example.
  * Improved formatting for the Cursor Cloud Agent command.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->