### PR TITLE
Make Discord ship-PR summaries glanceable with title and difficulty

### DIFF
--- a/skills/ship-pr/SKILL.md
+++ b/skills/ship-pr/SKILL.md
@@ -55,13 +55,22 @@ fetches the billed Cursor Cloud Agent usage and formats the cost line.
 - Otherwise pass the `bc-` id from the agent URL you were launched as
   (https://cursor.com/agents/{id}).
 
+**title:** a human headline of the change, not `ship owner/repo#N` (repo and PR
+already have links). Example:
+`OpenAPI spec fetches now count against daily quota`.
+
+**difficulty (always set):** `'Easy' | 'Medium' | 'Hard'`. Distinct from merge
+risk. Easy = small/localized; Medium = several files or real behavior change;
+Hard = architecture, migrations, subtle correctness, or wide blast radius.
+
 ```javascript
 import sendShippedPr from 'kody:@kentcdodds/discord/send-shipped-pr'
 
 export default async function main() {
 	return sendShippedPr({
 		agentId, // bc- id from the metadata socket or launch URL
-		title: 'PR title',
+		title: 'OpenAPI spec fetches now count against daily quota',
+		difficulty: 'Easy', // or 'Medium' | 'Hard'
 		summary: 'What shipped / parked / blocked and why.',
 		prUrl: 'https://github.com/owner/repo/pull/1',
 		repo: 'owner/repo',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Kent asked for Discord ship-PR summaries that are obvious at a glance: a real headline, plus a self-evaluation of how hard the change was.

This updates only the **Done → Discord** section of `skills/ship-pr/SKILL.md`. Loop, merge, BugBot, and other skills are unchanged. The longer kody-repo `ship-pr` variant is not copied in.

**title** must be a human headline of the change (example: `OpenAPI spec fetches now count against daily quota`). `ship owner/repo#N` is forbidden — repo and PR already have links.

**difficulty** is always set (`Easy` | `Medium` | `Hard`) and is distinct from merge risk:

- Easy = small/localized
- Medium = several files or a real behavior change
- Hard = architecture, migrations, subtle correctness, or wide blast radius

Formatted with `npm run format` (oxfmt, 80-column wrap).

## Test plan

- [x] Diff is confined to `skills/ship-pr/SKILL.md` Done → Discord
- [x] Example `title` is a human headline, not `ship owner/repo#N`
- [x] Example includes `difficulty: 'Easy' | 'Medium' | 'Hard'`
- [x] `npm run format` / `format:check` pass
- [ ] Not merged
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9c83aae1-d40f-47ca-bdf8-623d8ed23a3a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9c83aae1-d40f-47ca-bdf8-623d8ed23a3a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated shipped pull request reporting guidance to require a human-readable headline.
  * Added difficulty classification requirements with definitions for Easy, Medium, and Hard.
  * Updated the example to show the new title and difficulty values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->